### PR TITLE
port to Termux on Android

### DIFF
--- a/huskylib/MSVC.h
+++ b/huskylib/MSVC.h
@@ -153,6 +153,15 @@
 #ifndef S_ISREG
 #define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
+
+#ifndef S_IRUSR
+#define S_IRUSR S_IREAD
+#endif
+
+#ifndef S_IWUSR
+#define S_IWUSR S_IWRITE
+#endif
+
 /* define constants for 2nd parameter of access() function */
 #ifndef F_OK                  /* does file exist */
 #define F_OK 0

--- a/huskylib/UNIX.h
+++ b/huskylib/UNIX.h
@@ -100,7 +100,7 @@
 #endif
 
 #if defined (__LINUX__)
-    #if defined (__GLIBC__)
+    #if defined (__GLIBC__) || defined(__ANDROID__)
 #define HAS_SYS_STATVFS_H
     #else
 #define HAS_SYS_VFS_H

--- a/src/ioutil.c
+++ b/src/ioutil.c
@@ -385,7 +385,7 @@ int copy_file(const char * from, const char * to, const int force_rewrite)
     w_dbglog(LL_DEBUGZ, __FILE__ ":%u:copy_file()", __LINE__);
     fh = open(to,
               (force_rewrite ? 0 : O_EXCL) | O_CREAT | O_TRUNC | O_WRONLY | O_BINARY,
-              S_IREAD | S_IWRITE);
+              S_IRUSR | S_IWUSR);
 
     if(fh < 0)
     {
@@ -638,7 +638,7 @@ int lockFile(const char * lockfile, int advisoryLock)
     {
         while(advisoryLock > 0)
         {
-            fh = open(lockfile, O_CREAT | O_RDWR, S_IREAD | S_IWRITE);
+            fh = open(lockfile, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
 
             if(fh < 0)
             {
@@ -678,7 +678,7 @@ int lockFile(const char * lockfile, int advisoryLock)
     }
     else     /*  normal locking */
     {
-        fh = open(lockfile, O_CREAT | O_RDWR | O_EXCL, S_IREAD | S_IWRITE);
+        fh = open(lockfile, O_CREAT | O_RDWR | O_EXCL, S_IRUSR | S_IWUSR);
     }
 
     if(fh < 0)

--- a/src/temp.c
+++ b/src/temp.c
@@ -89,7 +89,7 @@ int MKSTEMPS(char * tempfilename)
             }
 
             *pp = '.';
-            fd  = open(ttt, O_EXCL | O_CREAT | O_RDWR, S_IREAD | S_IWRITE);
+            fd  = open(ttt, O_EXCL | O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
         }
         while(fd == -1 && errno == EEXIST && (strcpy(ttt, tempfilename), 1));
     }
@@ -102,7 +102,7 @@ int MKSTEMPS(char * tempfilename)
                 break;
             }
 
-            fd = open(ttt, O_EXCL | O_CREAT | O_RDWR, S_IREAD | S_IWRITE);
+            fd = open(ttt, O_EXCL | O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
         }
         while(fd == -1 && errno == EEXIST && (strcpy(ttt, tempfilename), 1));
     }


### PR DESCRIPTION
The S_IREAD & S_IWRITE defines in <sys/stat.h> are obsolete, and were replaced by S_IRUSR & S_IWUSR respectively.

S_IRUSR & S_IWUSR are supported by modern Linux, FreeBSD, Open Watcom 2.0 & MacOS X.

Evidently MSVC doesn't have S_IRUSR and S_IWUSR, so I've added macros that substitute the old S_IREAD & S_IWRITE defines.