### PR TITLE
C99 detection for stdbool.h

### DIFF
--- a/huskylib/DJGPP.h
+++ b/huskylib/DJGPP.h
@@ -83,16 +83,6 @@
     #endif
 #endif
 
-#ifndef __bool_true_false_are_defined
-#  define bool  unsigned char
-#  define false 0
-#  define true  1
-#  define __bool_true_false_are_defined 1
-#endif
-#ifndef HAS_BOOL
-#  define HAS_BOOL 1
-#endif
-
 #  include <unistd.h>
 #  include <io.h>
 #  define mysleep(x) sleep(x)

--- a/huskylib/MSC.h
+++ b/huskylib/MSC.h
@@ -81,16 +81,6 @@ void far * farcalloc(int n, int m);
 
 #  define USE_STAT_MACROS
 
-#ifndef __bool_true_false_are_defined
-#  define bool  unsigned char
-#  define false 0
-#  define true  1
-#  define __bool_true_false_are_defined 1
-#endif
-#ifndef HAS_BOOL
-#  define HAS_BOOL 1
-#endif
-
 typedef unsigned       bit;
 typedef unsigned char  byte;
 typedef signed char    sbyte;

--- a/huskylib/MSVC.h
+++ b/huskylib/MSVC.h
@@ -181,21 +181,6 @@
 #  define NEED_strnlen  1     /* our own strnlen() is needed */
 #endif
 
-#if _MSC_VER < 1800
-#  ifndef __bool_true_false_are_defined
-#    define bool  unsigned char
-#    define false 0
-#    define true  1
-#    define __bool_true_false_are_defined 1
-#  endif
-#else
-/* stdbool.h is present since Visual Studio 2013 (_MSC_VER == 1800) */
-#  include <stdbool.h>
-#endif
-#ifndef HAS_BOOL
-#  define HAS_BOOL 1
-#endif
-
 #  ifndef mymkdir
 #    define mymkdir _mkdir
 #  endif

--- a/huskylib/WATCOMC.h
+++ b/huskylib/WATCOMC.h
@@ -100,13 +100,6 @@ typedef unsigned short ushort;
 typedef signed long slong;
 typedef unsigned long ulong;
 
-#ifndef __bool_true_false_are_defined
-#  define bool  unsigned char
-#  define false 0
-#  define true  1
-#  define __bool_true_false_are_defined 1
-#endif
-
 typedef   signed char        hCHAR;              /*  1 byte */
 typedef   signed char       hSCHAR;              /*  1 byte */
 typedef unsigned char       hUCHAR;              /*  1 byte */

--- a/huskylib/compiler.h
+++ b/huskylib/compiler.h
@@ -517,6 +517,10 @@
     #ifndef HAS_STDINT_H
 #define HAS_STDINT_H 1
     #endif
+
+    #ifndef HAS_STDBOOL_H
+#define HAS_STDBOOL_H 1
+    #endif
 #endif
 /**** Compiler defines ****/
 
@@ -1399,6 +1403,15 @@ int trivial_farread(int handle, void far * buffer, unsigned len);
 #ifdef NEED_trivial_farwrite
 int trivial_farwrite(int handle, void far * buffer, unsigned len);
 
+#endif
+
+#ifdef HAS_STDBOOL_H
+#include <stdbool.h>
+#else
+#  define bool  int
+#  define false 0
+#  define true  1
+#  define __bool_true_false_are_defined 1
 #endif
 
 #ifndef TRUE


### PR DESCRIPTION
Use stdbool.h if __STDC_VERSION__ is a C99 compiler.

If pre-C99, or __STDC_VERSION__ is absent, make up our own bool type,
though in practice I'm not sure other parts of the code can build with
pre-C99 compilers any more.